### PR TITLE
support Wildcards IP

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,8 @@ import (
 
 var (
 	port           = flag.Int("port", 8080, "Example app port.")
-	appdashPort    = flag.Int("appdash.port", 8700, "Run appdash locally on this port.")
+	appdashAddr    = flag.String("appdash.addr", "localhost", "Run appdash on this addr.")
+	appdashPort    = flag.Int("appdash.port", 8700, "Run appdash on this port.")
 	lightstepToken = flag.String("lightstep.token", "", "Lightstep access token.")
 )
 
@@ -28,7 +29,8 @@ func main() {
 	if len(*lightstepToken) > 0 {
 		tracer = lightstepot.NewTracer(lightstepot.Options{AccessToken: *lightstepToken})
 	} else {
-		addr := startAppdashServer(*appdashPort)
+		appdashHost := fmt.Sprintf("%s:%d", *appdashAddr,*appdashPort)
+		addr := startAppdashServer(appdashHost)
 		tracer = appdashot.NewTracer(appdash.NewRemoteCollector(addr))
 	}
 
@@ -41,6 +43,6 @@ func main() {
 	mux.HandleFunc("/async", serviceHandler)
 	mux.HandleFunc("/service", serviceHandler)
 	mux.HandleFunc("/db", dbHandler)
-	fmt.Printf("Go to http://localhost:%d/home to start a request!\n", *port)
+	fmt.Printf("Go to http://%s:%d/home to start a request!\n", *appdashAddr, *port)
 	log.Fatal(http.ListenAndServe(addr, mux))
 }

--- a/util.go
+++ b/util.go
@@ -12,11 +12,11 @@ import (
 )
 
 // Returns the remote collector address.
-func startAppdashServer(appdashPort int) string {
+func startAppdashServer(appdashPort string) string {
 	store := appdash.NewMemoryStore()
 
 	// Listen on any available TCP port locally.
-	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: []byte(""), Port: 0})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func startAppdashServer(appdashPort int) string {
 	go cs.Start()
 
 	// Print the URL at which the web UI will be running.
-	appdashURLStr := fmt.Sprintf("http://localhost:%d", appdashPort)
+	appdashURLStr := fmt.Sprintf("http://%s", appdashPort)
 	appdashURL, err := url.Parse(appdashURLStr)
 	if err != nil {
 		log.Fatalf("Error parsing %s: %s", appdashURLStr, err)
@@ -43,7 +43,7 @@ func startAppdashServer(appdashPort int) string {
 	tapp.Store = store
 	tapp.Queryer = store
 	go func() {
-		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", appdashPort), tapp))
+		log.Fatal(http.ListenAndServe(fmt.Sprintf("%s", appdashPort), tapp))
 	}()
 	return fmt.Sprintf(":%d", collectorPort)
 }


### PR DESCRIPTION
When need run opentracing-example remotely，we need to access from a non-localhost IP.
Add function to support remote access.
Use command below to specify a remote listen address
`./opentracing-example-master -appdash.addr=10.10.10.1`